### PR TITLE
fix(implicit oklch): updates named colors on change

### DIFF
--- a/src/logics/colorLogic.ts
+++ b/src/logics/colorLogic.ts
@@ -25,6 +25,8 @@ export interface Color {
   chroma: number;
   lightness: number;
   css: string;
+  primary?: boolean;
+  secondary?: boolean;
 }
 
 export const colorLogic = kea<colorLogicType>([
@@ -51,13 +53,6 @@ export const colorLogic = kea<colorLogicType>([
             const toneVars = tones.map(
               ({ css }, tone) => `--colors_${index}_${tone}: ${css};`
             );
-            if (index === hues.length - 1) {
-              const secondaryVars = tones.map(
-                (_, tone) =>
-                  `--colors_secondary_${tone}: var(--colors_${index}_${tone});`
-              );
-              return [secondaryVars, toneVars];
-            }
             return [toneVars];
           })
           .flat();
@@ -111,14 +106,32 @@ export function connectColorLogic<T extends Logic = Logic>({
     listeners(({ values }) => ({
       [listenerAction as string]: async (_, breakpoint) => {
         await breakpoint(50);
-        colorLogic.actions.setColors(colors(values));
+        const colorValues = colors(values);
+        colorLogic.actions.setColors(colorValues);
         colorLogic.actions.setGreys(greys(values));
+        const primary = colorValues.find((color) => color[0].primary);
+        if (primary) {
+          colorLogic.actions.setPrimary(primary);
+        }
+        const secondary = colorValues.find((color) => color[0].secondary);
+        if (secondary) {
+          colorLogic.actions.setSecondary(secondary);
+        }
         await breakpoint(50);
       },
     }))(logic);
     afterMount(({ values }) => {
-      colorLogic.actions.setColors(colors(values));
+      const colorValues = colors(values);
+      colorLogic.actions.setColors(colorValues);
       colorLogic.actions.setGreys(greys(values));
+      const primary = colorValues.find((color) => color[0].primary);
+      if (primary) {
+        colorLogic.actions.setPrimary(primary);
+      }
+      const secondary = colorValues.find((color) => color[0].secondary);
+      if (secondary) {
+        colorLogic.actions.setSecondary(secondary);
+      }
     })(logic);
     beforeUnmount(({ values }) => {
       window.localStorage.setItem(storageKey, JSON.stringify(values));

--- a/src/logics/oklchImplicitLogic.ts
+++ b/src/logics/oklchImplicitLogic.ts
@@ -8,17 +8,10 @@ import {
 import { round } from "../utils/format";
 
 import { hueList } from "../utils/hueSpread";
-import { connectColorLogic } from "./colorLogic";
+import { Color, connectColorLogic } from "./colorLogic";
 import { colorLogicType } from "./colorLogicType";
 
 import type { oklchImplicitFormLogicType } from "./oklchImplicitLogicType";
-
-export interface Color {
-  hue: number;
-  chroma: number;
-  lightness: number;
-  css: string;
-}
 
 export interface ColorFormFields {
   centerPoint: number;
@@ -180,11 +173,12 @@ export const oklchImplicitFormLogic = kea<oklchImplicitFormLogicType>([
 function calculateColors(
   values: oklchImplicitFormLogicType["values"]
 ): [...Color[]][] {
-  const { lightnessShifts, chromaShifts, hueShifts, tintCount, hues } = values;
+  const { lightnessShifts, chromaShifts, hueShifts, tintCount, hues, centerPoint } = values;
 
   return hues.map((hue) =>
     Array.from({ length: tintCount }, (__, tintIndex) => {
       const values = {
+        primary: centerPoint === hue,
         // normalize at the center of the y axis
         hue: round((hueShifts[tintIndex].y - 0.5) * 10 + hue),
         // max out at 0.4 - need to add clipping eventually


### PR DESCRIPTION
I noticed that the primary and secondary colors weren't updating as expected.  Turns out I hadn't updated the connection logic, so it should be fixed now.